### PR TITLE
:bug: Fix CI build error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-linux)
+      racc (~> 1.4)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -178,6 +180,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.2-arm64-darwin)
+    sqlite3 (1.6.2-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -207,6 +210,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
```sh
May 4 06:45:16 PM  Your bundle only supports platforms ["arm64-darwin-22"] but your local platform
May 4 06:45:16 PM  is x86_64-linux. Add the current platform to the lockfile with `bundle lock
May 4 06:45:16 PM  --add-platform x86_64-linux` and try again.
```